### PR TITLE
Change image URL template to use DLCS instead of Wellcome DDS

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -109,7 +109,7 @@ class Record < ActiveRecord::Base
   end
 
   def image_service_urls
-    image_assets.map { |asset| "http://wellcomelibrary.org/iiif-img/#{identifier}-#{asset.fetch(:sequence_index)}/#{asset.fetch(:identifier)}" }
+    image_assets.map { |asset| "https://dlcs.io/iiif-img/wellcome/1/#{asset.fetch(:identifier)}" }
   end
 
   def publishers


### PR DESCRIPTION
This makes alpha use DLCS image API endpoints instead of Wellcome Library ones.
I think this is the only change that needs to happen.

@frankieroberto @jennpb - is there a staging environment where this can be tested?
